### PR TITLE
Add Stripe & PayPal payments

### DIFF
--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -156,6 +156,15 @@ MPESA_SHORTCODE_TYPE = 'paybill'
 
 MPESA_PASSKEY = os.environ.get('MPESA_PASS_KEY')
 
+# Stripe configuration
+STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY')
+STRIPE_PUBLISHABLE_KEY = os.environ.get('STRIPE_PUBLISHABLE_KEY')
+
+# PayPal configuration
+PAYPAL_CLIENT_ID = os.environ.get('PAYPAL_CLIENT_ID')
+PAYPAL_CLIENT_SECRET = os.environ.get('PAYPAL_CLIENT_SECRET')
+PAYPAL_MODE = os.environ.get('PAYPAL_MODE', 'sandbox')
+
 
 # Username for initiator (to be used in B2C, B2B, AccountBalance and TransactionStatusQuery Transactions)
 

--- a/orders/templates/orders/order_confirmation.html
+++ b/orders/templates/orders/order_confirmation.html
@@ -100,6 +100,7 @@
     <div class="mt-8 space-y-6">
 
         {% if order.payment.status != "PAID" %}
+            {% if order.payment_method == "mpesa" or order.payment_method == "MPESA" %}
             <!-- M-Pesa Payment Form -->
             <form action="{% url 'Mpesa:mpesa_trigger' %}"
                   method="post"
@@ -153,6 +154,23 @@
                     </button>
                 </div>
             </form>
+            {% elif order.payment_method == "card" %}
+            <!-- Stripe Payment Button -->
+            <div class="flex justify-center">
+                <a href="{% url 'orders:stripe_checkout' order.id %}"
+                   class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
+                    Pay with Card
+                </a>
+            </div>
+            {% elif order.payment_method == "paypal" %}
+            <!-- PayPal Payment Button -->
+            <div class="flex justify-center">
+                <a href="{% url 'orders:paypal_payment' order.id %}"
+                   class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
+                    Pay with PayPal
+                </a>
+            </div>
+            {% endif %}
         {% else %}
             <!-- Payment Already Done -->
             <div class="text-center text-green-600 font-semibold">

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -1,9 +1,22 @@
 from django.urls import path
-from .views import order_create, order_confirmation
+from .views import (
+    order_create,
+    order_confirmation,
+    stripe_checkout,
+    paypal_payment,
+    paypal_execute,
+    payment_success,
+    payment_cancel,
+)
 
 app_name = "orders"
 
 urlpatterns = [
     path('create', order_create, name="order_create"),
     path("confirmation/<int:order_id>", order_confirmation, name="order_confirmation"),
+    path('stripe/<int:order_id>/', stripe_checkout, name='stripe_checkout'),
+    path('paypal/<int:order_id>/', paypal_payment, name='paypal_payment'),
+    path('paypal/execute/<int:order_id>/', paypal_execute, name='paypal_execute'),
+    path('payment/success/<int:order_id>/', payment_success, name='payment_success'),
+    path('payment/cancel/<int:order_id>/', payment_cancel, name='payment_cancel'),
 ]

--- a/orders/views.py
+++ b/orders/views.py
@@ -3,12 +3,22 @@ from  cart.models import Cart
 from orders.forms import OrderForm
 from orders.models import Order, OrderItem
 from django.contrib import messages
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, reverse
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
 from orders.models import Order
 from django.db import transaction
+from django.conf import settings
+import stripe
+import paypalrestsdk
 
+# Configure Stripe and PayPal with keys from settings
+stripe.api_key = settings.STRIPE_SECRET_KEY
+paypalrestsdk.configure({
+    "mode": settings.PAYPAL_MODE,
+    "client_id": settings.PAYPAL_CLIENT_ID,
+    "client_secret": settings.PAYPAL_CLIENT_SECRET,
+})
 # Create your views here.
 
 
@@ -90,3 +100,93 @@ def order_create(request):
 def order_confirmation(request, order_id):
     order = get_object_or_404(Order, id=order_id)
     return render(request, "orders/order_confirmation.html", {"order":order})
+
+
+def stripe_checkout(request, order_id):
+    order = get_object_or_404(Order, id=order_id)
+    session = stripe.checkout.Session.create(
+        payment_method_types=["card"],
+        line_items=[{
+            "price_data": {
+                "currency": "kes",
+                "product_data": {"name": f"Order {order.id}"},
+                "unit_amount": int(order.get_total_cost()) * 100,
+            },
+            "quantity": 1,
+        }],
+        mode="payment",
+        success_url=request.build_absolute_uri(
+            reverse("orders:payment_success", args=[order.id])
+        ),
+        cancel_url=request.build_absolute_uri(
+            reverse("orders:payment_cancel", args=[order.id])
+        ),
+    )
+    return redirect(session.url)
+
+
+def paypal_payment(request, order_id):
+    order = get_object_or_404(Order, id=order_id)
+    payment = paypalrestsdk.Payment({
+        "intent": "sale",
+        "payer": {"payment_method": "paypal"},
+        "redirect_urls": {
+            "return_url": request.build_absolute_uri(
+                reverse("orders:paypal_execute", args=[order.id])
+            ),
+            "cancel_url": request.build_absolute_uri(
+                reverse("orders:payment_cancel", args=[order.id])
+            ),
+        },
+        "transactions": [{
+            "item_list": {
+                "items": [{
+                    "name": f"Order {order.id}",
+                    "sku": f"{order.id}",
+                    "price": str(order.get_total_cost()),
+                    "currency": "KES",
+                    "quantity": 1,
+                }]
+            },
+            "amount": {
+                "total": str(order.get_total_cost()),
+                "currency": "KES",
+            },
+            "description": f"Payment for Order {order.id}",
+        }],
+    })
+    if payment.create():
+        for link in payment.links:
+            if link.rel == "approval_url":
+                request.session["paypal_payment_id"] = payment.id
+                return redirect(link.href)
+    messages.error(request, "Unable to create PayPal payment")
+    return redirect("orders:order_confirmation", order.id)
+
+
+def paypal_execute(request, order_id):
+    payment_id = request.session.get("paypal_payment_id")
+    payer_id = request.GET.get("PayerID")
+    if not payment_id or not payer_id:
+        messages.error(request, "Invalid PayPal response")
+        return redirect("orders:order_confirmation", order_id)
+    payment = paypalrestsdk.Payment.find(payment_id)
+    if payment.execute({"payer_id": payer_id}):
+        order = get_object_or_404(Order, id=order_id)
+        order.paid = True
+        order.save()
+        return redirect("orders:payment_success", order.id)
+    else:
+        messages.error(request, "PayPal payment execution failed")
+        return redirect("orders:order_confirmation", order_id)
+
+
+def payment_success(request, order_id):
+    order = get_object_or_404(Order, id=order_id)
+    order.paid = True
+    order.save()
+    return render(request, "payment_result.html", {"message": "Payment successful"})
+
+
+def payment_cancel(request, order_id):
+    return render(request, "payment_result.html", {"error": "Payment cancelled"})

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ requests==2.32.3
 sqlparse==0.5.3
 tzdata==2025.2
 urllib3==2.4.0
+stripe==9.5.0
+paypalrestsdk==1.14.0


### PR DESCRIPTION
## Summary
- add Stripe and PayPal SDKs to requirements
- configure Stripe and PayPal credentials
- implement Stripe and PayPal payment flows
- extend order confirmation template with new payment options
- expose new payment URLs

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6881dadb6e70832a944fe12e70b36d10