### PR TITLE
Update payment label & add Geoapify autocomplete

### DIFF
--- a/orders/forms.py
+++ b/orders/forms.py
@@ -4,7 +4,7 @@ from .models import Order
 class OrderForm(forms.ModelForm):
     PAYMENT_CHOICES = [
         ('mpesa', 'M-Pesa'),
-        ('card',  'Credit/Debit Card'),
+        ('card',  'Pesapal Card'),
         ('paypal','PayPal'),
     ]
 

--- a/orders/templates/orders/order_create.html
+++ b/orders/templates/orders/order_create.html
@@ -121,3 +121,16 @@
   </div>
 </div>
 {% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var addressInput = document.getElementById('id_address');
+  if (addressInput && window.autocomplete) {
+    new autocomplete.GeocoderAutocomplete(addressInput, '{{ geoapify_api_key }}', {
+      filter: { circle: { lat: -1.286389, lon: 36.817223, radius: 30000 } }
+    });
+  }
+});
+</script>
+{% endblock %}

--- a/orders/views.py
+++ b/orders/views.py
@@ -98,6 +98,7 @@ def order_create(request):
         "cart_items":     cart_items,
         "selected_total": selected_total,
         "error_msg":      error_msg,
+        "geoapify_api_key": settings.GEOAPIFY_API_KEY,
     })
 
     


### PR DESCRIPTION
## Summary
- rename card payment option to Pesapal
- expose Geoapify API key in order_create view
- enable Geoapify location autocomplete on the address field in the order form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6884d997492c832abbdbf455217592b0