### PR TITLE
Add Paystack payments and transaction logging

### DIFF
--- a/Mpesa/urls.py
+++ b/Mpesa/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
 # path('trigger/', views.trigger, name='trigger-payment'),
 # path('mpesa/callback/', views.callback, name='mpesa-callback'),
 # path('trigger/<int:id>/', views.stk_push, name='mpesa_trigger'),
-path('trigger/', views.trigger_stk_push, name='mpesa_trigger'),
+path('trigger/', views.daraja_stk_push, name='daraja_stk_push'),
 path('callback/', views.stk_callback, name='mpesa_callback'),
 # path('payment<int:order_id>/',views.mpesa_payment, name='mpesa_payment'),
 ]

--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -167,6 +167,10 @@ PAYPAL_CLIENT_ID = os.environ.get('PAYPAL_CLIENT_ID')
 PAYPAL_CLIENT_SECRET = os.environ.get('PAYPAL_CLIENT_SECRET')
 PAYPAL_MODE = os.environ.get('PAYPAL_MODE', 'sandbox')
 
+# Paystack configuration
+PAYSTACK_PUBLIC_KEY = os.environ.get('PAYSTACK_PUBLIC_KEY')
+PAYSTACK_SECRET_KEY = os.environ.get('PAYSTACK_SECRET_KEY')
+
 
 # Username for initiator (to be used in B2C, B2B, AccountBalance and TransactionStatusQuery Transactions)
 

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from orders.models import Order, OrderItem
+from orders.models import Order, OrderItem, Transaction
 
 
 # Register your models here.
@@ -14,3 +14,9 @@ class OrderAdmin(admin.ModelAdmin):
     list_display = ["id", "full_name", "email"]
     inlines = [OrderItemInline]
     readonly_fields = ("created_at",)
+
+
+@admin.register(Transaction)
+class TransactionAdmin(admin.ModelAdmin):
+    list_display = ("user", "amount", "method", "gateway", "status", "reference", "created_at")
+    list_filter = ("method", "gateway", "status")

--- a/orders/forms.py
+++ b/orders/forms.py
@@ -4,7 +4,7 @@ from .models import Order
 class OrderForm(forms.ModelForm):
     PAYMENT_CHOICES = [
         ('mpesa', 'M-Pesa'),
-        ('card',  'debit/credit card'),
+        ('card',  'Card (Visa/MasterCard)'),
         ('paypal','PayPal'),
     ]
 

--- a/orders/migrations/0008_transaction.py
+++ b/orders/migrations/0008_transaction.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+from django.conf import settings
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('orders', '0007_order_payment_intent_id_order_payment_status_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Transaction',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('amount', models.DecimalField(decimal_places=2, max_digits=10)),
+                ('method', models.CharField(choices=[('card', 'Card'), ('mpesa', 'M-Pesa'), ('paypal', 'PayPal')], max_length=10)),
+                ('gateway', models.CharField(choices=[('paystack', 'Paystack'), ('daraja', 'Daraja'), ('paypal', 'PayPal')], max_length=10)),
+                ('status', models.CharField(default='pending', max_length=20)),
+                ('reference', models.CharField(max_length=100)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/orders/models.py
+++ b/orders/models.py
@@ -46,3 +46,26 @@ class OrderItem(models.Model):
 
     def __str__(self):
         return f"{self.quantity} x {self.product.name}"
+
+
+class Transaction(models.Model):
+    METHOD_CHOICES = (
+        ("card", "Card"),
+        ("mpesa", "M-Pesa"),
+        ("paypal", "PayPal"),
+    )
+    GATEWAY_CHOICES = (
+        ("paystack", "Paystack"),
+        ("daraja", "Daraja"),
+        ("paypal", "PayPal"),
+    )
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+    method = models.CharField(max_length=10, choices=METHOD_CHOICES)
+    gateway = models.CharField(max_length=10, choices=GATEWAY_CHOICES)
+    status = models.CharField(max_length=20, default="pending")
+    reference = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user} - {self.method} - {self.reference}"

--- a/orders/templates/orders/order_confirmation.html
+++ b/orders/templates/orders/order_confirmation.html
@@ -102,7 +102,7 @@
         {% if order.payment.status != "PAID" %}
             {% if order.payment_method == "mpesa" or order.payment_method == "MPESA" %}
             <!-- M-Pesa Payment Form -->
-            <form action="{% url 'Mpesa:mpesa_trigger' %}"
+            <form action="{% url 'Mpesa:daraja_stk_push' %}"
                   method="post"
                   class="max-w-md mx-auto bg-white p-6 rounded-xl shadow-md space-y-6">
                 {% csrf_token %}
@@ -155,9 +155,9 @@
                 </div>
             </form>
             {% elif order.payment_method == "card" %}
-            <!-- Stripe Payment Button -->
+            <!-- Paystack Payment Button -->
             <div class="flex justify-center">
-                <a href="{% url 'orders:stripe_checkout' order.id %}"
+                <a href="{% url 'orders:paystack_checkout' order.id %}"
                    class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
                     Pay with Card
                 </a>
@@ -165,7 +165,7 @@
             {% elif order.payment_method == "paypal" %}
             <!-- PayPal Payment Button -->
             <div class="flex justify-center">
-                <a href="{% url 'orders:paypal_payment' order.id %}"
+                <a href="{% url 'orders:paypal_checkout' order.id %}"
                    class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
                     Pay with PayPal
                 </a>

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -6,12 +6,15 @@ from .views import (
     order_create,
     order_confirmation,
     stripe_checkout,
-    paypal_payment,
+    paystack_checkout,
+    paypal_checkout,
     paypal_execute,
     payment_success,
     payment_cancel,
     Stripe_payment_success,
     stripe_webhook,
+    paystack_webhook,
+    paypal_webhook,
 )
 
 
@@ -22,13 +25,17 @@ urlpatterns = [
     path("confirmation/<int:order_id>", order_confirmation, name="order_confirmation"),
     # Reverse geocode API
     path('api/reverse-geocode/', get_location_info, name='reverse_geocode'),
-    # Stripe payment urls
+    # Stripe payment urls (not linked from UI)
     path('stripe/<int:order_id>/', stripe_checkout, name='stripe_checkout'),
     path("success/<int:order_id>/", Stripe_payment_success, name="payment_success"),
     path("webhook/stripe/", stripe_webhook, name="stripe-webhook"),
-    # paypal payment urls
-    path('paypal/<int:order_id>/', paypal_payment, name='paypal_payment'),
+    # Paystack payment urls
+    path('paystack/<int:order_id>/', paystack_checkout, name='paystack_checkout'),
+    path('webhook/paystack/', paystack_webhook, name='paystack_webhook'),
+    # PayPal payment urls
+    path('paypal/<int:order_id>/', paypal_checkout, name='paypal_checkout'),
     path('paypal/execute/<int:order_id>/', paypal_execute, name='paypal_execute'),
+    path('webhook/paypal/', paypal_webhook, name='paypal_webhook'),
     path('payment/success/<int:order_id>/', payment_success, name='payment_success'),
     path('payment/cancel/<int:order_id>/', payment_cancel, name='payment_cancel'),
 


### PR DESCRIPTION
## Summary
- integrate Paystack card payments alongside existing M-PESA and PayPal options
- add Transaction model and admin registration to track payment history
- wire up webhook handlers for Paystack and PayPal, keep Stripe code for dev use

## Testing
- `python -m py_compile orders/views.py orders/forms.py Mpesa/views.py Mpesa/urls.py orders/models.py orders/admin.py orders/urls.py Rahim_Online_ClothesStore/settings.py`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688b8c6d5530832abf68b83ecfed6dba