### PR TITLE
Refactor payment flow to use Paystack for card and M-Pesa

### DIFF
--- a/Mpesa/urls.py
+++ b/Mpesa/urls.py
@@ -7,7 +7,8 @@ urlpatterns = [
 # path('trigger/', views.trigger, name='trigger-payment'),
 # path('mpesa/callback/', views.callback, name='mpesa-callback'),
 # path('trigger/<int:id>/', views.stk_push, name='mpesa_trigger'),
-path('trigger/', views.daraja_stk_push, name='daraja_stk_push'),
-path('callback/', views.stk_callback, name='mpesa_callback'),
+# [Inactive] Preserved for future testing
+# path('trigger/', views.daraja_stk_push, name='daraja_stk_push'),
+# path('callback/', views.stk_callback, name='mpesa_callback'),
 # path('payment<int:order_id>/',views.mpesa_payment, name='mpesa_payment'),
 ]

--- a/Mpesa/views.py
+++ b/Mpesa/views.py
@@ -14,6 +14,7 @@ import traceback
 # Initialize MpesaClient once
 cl = MpesaClient()
 
+# [Inactive] Preserved for future testing
 @csrf_exempt
 def daraja_stk_push(request):
     if request.method == 'POST':
@@ -87,6 +88,7 @@ def daraja_stk_push(request):
     return render(request, "orders/order_confirmation.html", {
         "error": "Invalid request method."
     })
+# [Inactive] Preserved for future testing
 @csrf_exempt
 def stk_callback(request):
     try:

--- a/Rahim_Online_ClothesStore/urls.py
+++ b/Rahim_Online_ClothesStore/urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
                   path('utilities/', include('utilities.urls')), 
                   path('cart/', include('cart.urls')),
                   path('orders/', include("orders.urls")),
-                  path('mpesa/', include('Mpesa.urls')),
+                  # path('mpesa/', include('Mpesa.urls')),  # [Inactive] Preserved for future testing
                   path('', views.product_list, name='index'),
                   
                   path('<slug:category_slug>/', views.product_list, name='product_list_by_category'),

--- a/orders/forms.py
+++ b/orders/forms.py
@@ -3,9 +3,9 @@ from .models import Order
 
 class OrderForm(forms.ModelForm):
     PAYMENT_CHOICES = [
-        ('mpesa', 'M-Pesa'),
-        ('card',  'Card (Visa/MasterCard)'),
-        ('paypal','PayPal'),
+        ('card', 'Paystack (Card)'),
+        ('mpesa', 'Paystack (M-Pesa)'),
+        ('paypal', 'PayPal'),
     ]
 
     payment_method = forms.ChoiceField(

--- a/orders/templates/orders/order_confirmation.html
+++ b/orders/templates/orders/order_confirmation.html
@@ -100,68 +100,37 @@
     <div class="mt-8 space-y-6">
 
         {% if order.payment.status != "PAID" %}
-            {% if order.payment_method == "mpesa" or order.payment_method == "MPESA" %}
-            <!-- M-Pesa Payment Form -->
-            <form action="{% url 'Mpesa:daraja_stk_push' %}"
-                  method="post"
-                  class="max-w-md mx-auto bg-white p-6 rounded-xl shadow-md space-y-6">
+            {% if order.payment_method in ['card', 'mpesa'] %}
+            <!-- Paystack Payment Button -->
+            <div class="flex justify-center">
+                <a href="{% url 'orders:paystack_checkout' order.id %}?payment_method={{ order.payment_method }}"
+                   class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
+                    Pay with {% if order.payment_method == "mpesa" %}M-Pesa{% else %}Card{% endif %}
+                </a>
+            </div>
+            {% comment %}
+            # [Inactive] Preserved for future testing - Legacy Daraja STK form
+            <form action="{% url 'Mpesa:daraja_stk_push' %}" method="post" class="max-w-md mx-auto bg-white p-6 rounded-xl shadow-md space-y-6">
                 {% csrf_token %}
                 <input type="hidden" name="order_id" value="{{ order.id }}">
-
                 <div>
-                    <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">
-                        Phone Number
-                    </label>
-                    <input
-                        type="text"
-                        name="phone_number"
-                        id="phone_number"
-                        placeholder="e.g., 254712345678"
-                        required
-                        class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-
-                    <label for="Amount" class="block text-sm font-medium text-gray-700 mt-4 mb-1">
-                        Amount
-                    </label>
-                    <input
-                        type="number"
-                        name="Amount"
-                        id="Amount"
-                        readonly
-                        value="{{ order.get_total_cost }}"
-                        class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none"
-                    >
+                    <label for="phone_number" class="block text-sm font-medium text-gray-700 mb-1">Phone Number</label>
+                    <input type="text" name="phone_number" id="phone_number" placeholder="e.g., 254712345678" required class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <label for="Amount" class="block text-sm font-medium text-gray-700 mt-4 mb-1">Amount</label>
+                    <input type="number" name="Amount" id="Amount" readonly value="{{ order.get_total_cost }}" class="w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none">
                 </div>
-
-                <!-- Pay Button -->
                 <div class="flex justify-center items-center">
-                    <button
-                        type="submit"
-                        class="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                    >
+                    <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
                         <div class="inline-flex items-center space-x-2">
-                            <svg xmlns="http://www.w3.org/2000/svg"
-                                 class="h-5 w-5"
-                                 viewBox="0 0 20 20"
-                                 fill="currentColor">
-                                <path fill-rule="evenodd"
-                                      d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z"
-                                      clip-rule="evenodd" />
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
                             </svg>
                             <span>Make M-Pesa Payment</span>
                         </div>
                     </button>
                 </div>
             </form>
-            {% elif order.payment_method == "card" %}
-            <!-- Paystack Payment Button -->
-            <div class="flex justify-center">
-                <a href="{% url 'orders:paystack_checkout' order.id %}"
-                   class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
-                    Pay with Card
-                </a>
-            </div>
+            {% endcomment %}
             {% elif order.payment_method == "paypal" %}
             <!-- PayPal Payment Button -->
             <div class="flex justify-center">

--- a/orders/templates/orders/order_create.html
+++ b/orders/templates/orders/order_create.html
@@ -83,7 +83,8 @@
           {% endif %}
         </div>
 
-        {# MPESA phone #}
+        {# [Inactive] Preserved for future testing - MPESA phone input #}
+        {#
         <div id="mpesa-phone-container" class="mb-4 hidden">
           <label class="block text-sm font-medium text-gray-700 mb-1">
             {{ form.mpesa_phone.label }}<span class="text-red-500">*</span>
@@ -93,6 +94,7 @@
             <p class="mt-1 text-sm text-red-600">{{ form.mpesa_phone.errors|striptags }}</p>
           {% endif %}
         </div>
+        #}
 
         <!-- Order Total -->
         <div class="mt-6 border-t border-gray-200 pt-4">


### PR DESCRIPTION
## Summary
- route card and M-Pesa payments through Paystack with dynamic channel selection
- hide legacy Daraja STK integration and mark views/urls as inactive
- show only Paystack and PayPal options in checkout templates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_688b9eb5fd90832abb3c1205d40de095