### PR TITLE
Hide PayPal option in templates

### DIFF
--- a/orders/templates/orders/order_confirmation.html
+++ b/orders/templates/orders/order_confirmation.html
@@ -108,15 +108,18 @@
             Pay with {% if order.payment_method == "mpesa" %}M-Pesa{% else %}Card{% endif %}
         </a>
     </div>
-    {% elif order.payment_method == "paypal" %}
-    <!-- PayPal Payment Button -->
-    <div class="flex justify-center">
-        <a href="{% url 'orders:paypal_checkout' order.id %}"
-           class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
-            Pay with PayPal
-        </a>
-    </div>
-    {% endif %}
+      {% elif order.payment_method == "paypal" %}
+      <!-- PayPal temporarily removed -->
+      {#
+      <!-- PayPal Payment Button -->
+      <div class="flex justify-center">
+          <a href="{% url 'orders:paypal_checkout' order.id %}"
+             class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-lg shadow-md">
+              Pay with PayPal
+          </a>
+      </div>
+      #}
+      {% endif %}
 {% else %}
     <!-- Payment Already Done -->
     <div class="text-center text-green-600 font-semibold">

--- a/orders/templates/orders/order_create.html
+++ b/orders/templates/orders/order_create.html
@@ -63,25 +63,29 @@
         {# hide the default widget #}
         {% render_field form.payment_method class="sr-only" %}
 
-        <div class="space-y-2 mb-4">
-          {% for choice in form.payment_method %}
-            <label class="flex items-center p-3 border rounded-lg cursor-pointer hover:border-indigo-300
-                          {% if choice.data.value == form.payment_method.value %}border-indigo-400 bg-indigo-50{% else %}border-gray-300{% endif %}">
-              <input type="radio"
-                     name="{{ form.payment_method.name }}"
-                     value="{{ choice.data.value }}"
-                     class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300"
-                     {% if choice.data.value == form.payment_method.value %}checked{% endif %}>
-              <span class="ml-3 text-sm font-medium text-gray-700">
-                {{ choice.choice_label }}
-              </span>
-            </label>
-          {% endfor %}
+          <div class="space-y-2 mb-4">
+            {% for choice in form.payment_method %}
+              {% if choice.data.value != 'paypal' %}
+              <label class="flex items-center p-3 border rounded-lg cursor-pointer hover:border-indigo-300
+                            {% if choice.data.value == form.payment_method.value %}border-indigo-400 bg-indigo-50{% else %}border-gray-300{% endif %}">
+                <input type="radio"
+                       name="{{ form.payment_method.name }}"
+                       value="{{ choice.data.value }}"
+                       class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300"
+                       {% if choice.data.value == form.payment_method.value %}checked{% endif %}>
+                <span class="ml-3 text-sm font-medium text-gray-700">
+                  {{ choice.choice_label }}
+                </span>
+              </label>
+              {% else %}
+              <!-- PayPal temporarily removed -->
+              {% endif %}
+            {% endfor %}
 
-          {% if error_msg and form.payment_method.errors %}
-            <p class="mt-2 text-sm text-red-600">{{ form.payment_method.errors|striptags }}</p>
-          {% endif %}
-        </div>
+            {% if error_msg and form.payment_method.errors %}
+              <p class="mt-2 text-sm text-red-600">{{ form.payment_method.errors|striptags }}</p>
+            {% endif %}
+          </div>
 {%comment%}
          [Inactive] Preserved for future testing - MPESA phone input 
         {#


### PR DESCRIPTION
## Summary
- hide PayPal choice during checkout form rendering
- comment out PayPal button on order confirmation page

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_688da6df3d88832a9ae75b6edbae1da1