### PR TITLE
Add real-time delivery tracking with Django Channels

### DIFF
--- a/Rahim_Online_ClothesStore/asgi.py
+++ b/Rahim_Online_ClothesStore/asgi.py
@@ -1,16 +1,18 @@
-"""
-ASGI config for CodeAlpa_Online_ClothesStore project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
-"""
-
+"""ASGI config for Rahim_Online_ClothesStore project."""
 import os
 
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+import orders.routing
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'CodeAlpa_Online_ClothesStore.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Rahim_Online_ClothesStore.settings')
 
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AuthMiddlewareStack(
+        URLRouter(orders.routing.websocket_urlpatterns)
+    ),
+})

--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'channels',
     'product_app',
     'cart.apps.CartConfig',
     'orders.apps.OrdersConfig',
@@ -121,6 +122,7 @@ TEMPLATES = [
     },
 ]
 
+ASGI_APPLICATION = 'Rahim_Online_ClothesStore.asgi.application'
 WSGI_APPLICATION = 'Rahim_Online_ClothesStore.wsgi.application'
 # The Mpesa environment to use
 # Possible values: sandbox, production
@@ -198,11 +200,17 @@ DATABASES = {
           'OPTIONS': {
               'charset': 'utf8mb4',
             'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-           
+
         }
 
 
     }
+}
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    },
 }
 
 

--- a/orders/consumers.py
+++ b/orders/consumers.py
@@ -1,0 +1,69 @@
+import asyncio
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from .models import Order, OrderItem
+
+class DeliveryTrackerConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.order_id = self.scope["url_route"]["kwargs"]["order_id"]
+        self.item_id = self.scope["url_route"]["kwargs"]["item_id"]
+
+        self.order = await self.get_order(self.order_id)
+        self.item = await self.get_item(self.item_id)
+
+        if not self.order or not self.item or not self.item.warehouse:
+            await self.close()
+            return
+
+        if self.item.delivery_status != "dispatched":
+            await self.close()
+            return
+
+        await self.set_status("in_transit")
+        await self.accept()
+
+        start_lat = self.item.warehouse.latitude
+        start_lng = self.item.warehouse.longitude
+        end_lat = self.order.latitude
+        end_lng = self.order.longitude
+
+        steps = 30
+        lat_step = (end_lat - start_lat) / steps
+        lng_step = (end_lng - start_lng) / steps
+
+        for i in range(1, steps + 1):
+            lat = start_lat + lat_step * i
+            lng = start_lng + lng_step * i
+            await self.send_json({
+                "latitude": lat,
+                "longitude": lng,
+                "status": "in_transit",
+            })
+            await asyncio.sleep(0.5)
+
+        await self.set_status("delivered")
+        await self.send_json({
+            "latitude": end_lat,
+            "longitude": end_lng,
+            "status": "delivered",
+        })
+        await self.close()
+
+    @database_sync_to_async
+    def get_order(self, order_id):
+        try:
+            return Order.objects.get(pk=order_id)
+        except Order.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def get_item(self, item_id):
+        try:
+            return OrderItem.objects.select_related("warehouse").get(pk=item_id)
+        except OrderItem.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def set_status(self, status):
+        self.item.delivery_status = status
+        self.item.save(update_fields=["delivery_status"])

--- a/orders/migrations/0004_orderitem_delivery_status.py
+++ b/orders/migrations/0004_orderitem_delivery_status.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orders', '0003_orderitem_warehouse'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='orderitem',
+            name='delivery_status',
+            field=models.CharField(
+                choices=[('pending', 'Pending'), ('dispatched', 'Dispatched'), ('in_transit', 'In transit'), ('delivered', 'Delivered')],
+                default='pending',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/orders/models.py
+++ b/orders/models.py
@@ -37,12 +37,24 @@ class Order(models.Model):
 
 
 class OrderItem(models.Model):
+    DELIVERY_STATUS_CHOICES = [
+        ("pending", "Pending"),
+        ("dispatched", "Dispatched"),
+        ("in_transit", "In transit"),
+        ("delivered", "Delivered"),
+    ]
+
     order = models.ForeignKey(Order, related_name="items", on_delete=models.CASCADE)
     product = models.ForeignKey(Product, related_name="order_items", on_delete=models.CASCADE)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     quantity = models.PositiveIntegerField(default=1)
     warehouse = models.ForeignKey(
         Warehouse, null=True, blank=True, on_delete=models.SET_NULL
+    )
+    delivery_status = models.CharField(
+        max_length=20,
+        choices=DELIVERY_STATUS_CHOICES,
+        default="pending",
     )
 
     def get_cost(self):

--- a/orders/routing.py
+++ b/orders/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"ws/track/(?P<order_id>\d+)/(?P<item_id>\d+)/", consumers.DeliveryTrackerConsumer.as_asgi()),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ django-tailwind==4.0.1
 django-widget-tweaks==1.5.0
 djangorestframework==3.16.0
 djangorestframework_simplejwt==5.5.0
+channels==4.1.0
 idna==3.10
 mysqlclient==2.2.7
 paypalrestsdk==1.13.3

--- a/users/templates/users/accounts/my_orders.html
+++ b/users/templates/users/accounts/my_orders.html
@@ -24,17 +24,17 @@
                     {% for item in order.items.all %}
                         <div class="border rounded p-2 mt-2">
                             <p>{{ item.quantity }} x {{ item.product.name }}</p>
-                            {% if item.warehouse and order.latitude and order.longitude %}
+                            <p class="text-sm">Delivery status: {{ item.delivery_status }}</p>
+                            {% if item.delivery_status == "dispatched" %}
                                 <button class="mt-1 text-blue-600 text-sm underline track-item-btn"
                                         data-order-id="{{ order.id }}"
                                         data-item-id="{{ item.id }}"
-                                        data-wlat="{{ item.warehouse.latitude }}"
-                                        data-wlng="{{ item.warehouse.longitude }}"
                                         data-clat="{{ order.latitude }}"
                                         data-clng="{{ order.longitude }}">
                                     Track Item
                                 </button>
                                 <div id="map-{{ order.id }}-{{ item.id }}" class="w-full rounded border mt-2 hidden" style="height:300px;"></div>
+                                <p id="status-{{ order.id }}-{{ item.id }}" class="text-sm mt-2"></p>
                             {% else %}
                                 <p class="text-sm text-gray-500 mt-1">Tracking not available.</p>
                             {% endif %}
@@ -53,29 +53,35 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
-const geoapifyKey = "{{ geoapify_api_key }}";
 document.querySelectorAll('.track-item-btn').forEach(btn => {
     btn.addEventListener('click', function() {
         const orderId = this.dataset.orderId;
         const itemId = this.dataset.itemId;
-        const wlat = parseFloat(this.dataset.wlat);
-        const wlng = parseFloat(this.dataset.wlng);
         const clat = parseFloat(this.dataset.clat);
         const clng = parseFloat(this.dataset.clng);
         const mapDiv = document.getElementById(`map-${orderId}-${itemId}`);
+        const statusEl = document.getElementById(`status-${orderId}-${itemId}`);
         if (mapDiv.classList.contains('hidden')) {
             mapDiv.classList.remove('hidden');
-            if (!mapDiv.dataset.mapLoaded) {
-                const map = L.map(mapDiv).setView([clat, clng], 6);
-                L.tileLayer(`https://maps.geoapify.com/v1/tile/osm-carto/{z}/{x}/{y}.png?apiKey=${geoapifyKey}`, {
-                    attribution: '&copy; OpenStreetMap contributors'
-                }).addTo(map);
-                L.marker([wlat, wlng]).addTo(map).bindPopup('Warehouse');
-                L.marker([clat, clng]).addTo(map).bindPopup('Destination');
-                L.polyline([[wlat, wlng], [clat, clng]], {color: 'blue'}).addTo(map);
-                map.fitBounds([[wlat, wlng], [clat, clng]]);
-                mapDiv.dataset.mapLoaded = true;
-            }
+            const map = L.map(mapDiv).setView([clat, clng], 13);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:19}).addTo(map);
+            const truckIcon = L.icon({
+                iconUrl: 'https://cdn-icons-png.flaticon.com/512/1557/1557523.png',
+                iconSize: [32,32],
+                iconAnchor: [16,16],
+            });
+            const marker = L.marker([clat, clng], {icon: truckIcon}).addTo(map);
+            const socket = new WebSocket(`ws://${window.location.host}/ws/track/${orderId}/${itemId}/`);
+            socket.onmessage = function(event) {
+                const data = JSON.parse(event.data);
+                if (data.latitude && data.longitude) {
+                    marker.setLatLng([data.latitude, data.longitude]);
+                    map.setView([data.latitude, data.longitude]);
+                }
+                if (data.status) {
+                    statusEl.textContent = data.status;
+                }
+            };
         } else {
             mapDiv.classList.add('hidden');
         }


### PR DESCRIPTION
## Summary
- add delivery_status to OrderItem and simulate movement via DeliveryTrackerConsumer
- configure Django Channels with in-memory layers and websocket routing
- enable frontend tracking with Leaflet map and WebSocket status updates

## Testing
- `pip install channels==4.1.0` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'channels')*

------
https://chatgpt.com/codex/tasks/task_e_688e15bac410832aae9c109f93558b75