### PR TITLE
Implement order destination geocoding with Geoapify and Nominatim fallback

### DIFF
--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -15,9 +15,11 @@ import os
 from django.db import models
 from django.db.models import CharField
 from dotenv import load_dotenv
+import environ
 from datetime import timedelta
 # Load environment   variables from .env file
 load_dotenv()
+env = environ.Env()
 
 
 
@@ -183,7 +185,9 @@ MPESA_INITIATOR_USERNAME = 'initiator_username'
 
 MPESA_INITIATOR_SECURITY_CREDENTIAL = 'initiator_security_credential'
 # Geopify settings
-GEOAPIFY_API_KEY = os.environ.get('GEOAPIFY_API_KEY')
+GEOAPIFY_API_KEY = env('GEOAPIFY_API_KEY', default='')
+GEOCODING_TIMEOUT = 6
+GEOCODING_USER_AGENT = 'RahimOnline/1.0 (contact: admin@example.com)'
 
 
 

--- a/orders/admin.py
+++ b/orders/admin.py
@@ -1,20 +1,32 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 
+from .services.destinations import ensure_order_coords
 from orders.models import Order, OrderItem, Transaction
 
+@admin.action(description="Geocode destination (missing only)")
+def geocode_destination(modeladmin, request, queryset):
+    updated = 0
+    for order in queryset:
+        if order.latitude is not None and order.longitude is not None:
+            continue
+        try:
+            if ensure_order_coords(order):
+                updated += 1
+        except Exception as exc:  # pragma: no cover - defensive
+            modeladmin.message_user(request, f"{order.id}: {exc}", level=messages.WARNING)
+    modeladmin.message_user(request, f"Geocoded {updated} orders.")
 
 # Register your models here.
 class OrderItemInline(admin.TabularInline):
     model = OrderItem
     raw_id_fields = ["product", "warehouse"]
 
-
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
+    actions = [geocode_destination]
     list_display = ["id", "full_name", "email"]
     inlines = [OrderItemInline]
     readonly_fields = ("created_at",)
-
 
 @admin.register(Transaction)
 class TransactionAdmin(admin.ModelAdmin):

--- a/orders/management/commands/backfill_order_coords.py
+++ b/orders/management/commands/backfill_order_coords.py
@@ -1,0 +1,34 @@
+"""Backfill missing order coordinates."""
+
+from django.core.management.base import BaseCommand
+
+from orders.models import Order
+from orders.services.destinations import ensure_order_coords
+
+
+class Command(BaseCommand):
+    help = "Geocode recent orders and fill missing coordinates"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--limit", type=int, default=200)
+        parser.add_argument("--only-missing", action="store_true")
+
+    def handle(self, *args, **opts):
+        limit = opts["limit"]
+        qs = Order.objects.order_by("-id")
+        if opts["only_missing"]:
+            qs = qs.filter(latitude__isnull=True, longitude__isnull=True)
+        qs = qs[:limit]
+        updated = skipped = failed = 0
+        for order in qs:
+            try:
+                changed = ensure_order_coords(order)
+            except Exception as exc:  # pragma: no cover - defensive
+                failed += 1
+                self.stderr.write(f"{order.id}: {exc}")
+            else:
+                if changed:
+                    updated += 1
+                else:
+                    skipped += 1
+        self.stdout.write(self.style.SUCCESS(f"updated={updated} skipped={skipped} failed={failed}"))

--- a/orders/services/__init__.py
+++ b/orders/services/__init__.py
@@ -4,8 +4,8 @@ from typing import Iterable, Tuple
 
 from product_app.models import ProductStock
 
-from .assignment import pick_warehouse
-from .models import Order, OrderItem
+from ..assignment import pick_warehouse
+from ..models import Order, OrderItem
 
 
 def create_order_with_items(user, cart: Iterable[Tuple], coords=None):

--- a/orders/services/destinations.py
+++ b/orders/services/destinations.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.utils import timezone
+
+from ..models import Order
+from .geocoding import geocode_address
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_order_coords(order: Order, *, force: bool = False) -> bool:
+    """Ensure an order has latitude/longitude; return True if updated."""
+    if not force and order.latitude is not None and order.longitude is not None:
+        return False
+    if not order.address:
+        return False
+    try:
+        coords = geocode_address(order.address)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Geocode lookup failed: %s", exc)
+        return False
+    if not coords:
+        return False
+    lat, lng = coords
+    order.latitude = lat
+    order.longitude = lng
+    order.coords_source = "geocode"
+    order.coords_updated_at = timezone.now()
+    order.save(update_fields=["latitude", "longitude", "coords_source", "coords_updated_at"])
+    return True

--- a/orders/services/geocoding.py
+++ b/orders/services/geocoding.py
@@ -1,0 +1,98 @@
+import logging
+import time
+from typing import Optional, Tuple
+
+import httpx
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+GEOAPIFY_URL = "https://api.geoapify.com/v1/geocode/search"
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(timeout=settings.GEOCODING_TIMEOUT, follow_redirects=False)
+
+
+def _geocode_geoapify(address: str) -> Optional[Tuple[float, float]]:
+    api_key = getattr(settings, "GEOAPIFY_API_KEY", "")
+    if not api_key:
+        return None
+    params = {"text": address, "apiKey": api_key}
+    headers = {"User-Agent": settings.GEOCODING_USER_AGENT}
+    for attempt in range(2):
+        try:
+            with _client() as client:
+                resp = client.get(GEOAPIFY_URL, params=params, headers=headers)
+        except httpx.HTTPError as exc:
+            logger.warning("Geoapify request error: %s", exc)
+            return None
+        if resp.status_code == 429 and attempt == 0:
+            time.sleep(1)
+            continue
+        if resp.status_code != 200:
+            logger.warning("Geoapify response %s", resp.status_code)
+            return None
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            logger.warning("Geoapify invalid JSON: %s", exc)
+            return None
+        features = data.get("features") or []
+        if not features:
+            return None
+        feat = features[0]
+        props = feat.get("properties", {})
+        lat = props.get("lat")
+        lon = props.get("lon")
+        if lat is None or lon is None:
+            coords = feat.get("geometry", {}).get("coordinates")
+            if coords and len(coords) >= 2:
+                lon, lat = coords[0], coords[1]
+        if lat is not None and lon is not None:
+            try:
+                return float(lat), float(lon)
+            except (TypeError, ValueError):
+                return None
+        return None
+    return None
+
+
+def _geocode_nominatim(address: str) -> Optional[Tuple[float, float]]:
+    params = {"q": address, "format": "json", "limit": 1}
+    headers = {"User-Agent": settings.GEOCODING_USER_AGENT}
+    for attempt in range(2):
+        try:
+            with _client() as client:
+                resp = client.get(NOMINATIM_URL, params=params, headers=headers)
+        except httpx.HTTPError as exc:
+            logger.warning("Nominatim request error: %s", exc)
+            return None
+        if resp.status_code == 429 and attempt == 0:
+            time.sleep(1)
+            continue
+        if resp.status_code != 200:
+            logger.warning("Nominatim response %s", resp.status_code)
+            return None
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            logger.warning("Nominatim invalid JSON: %s", exc)
+            return None
+        if not data:
+            return None
+        first = data[0]
+        try:
+            return float(first["lat"]), float(first["lon"])
+        except (KeyError, TypeError, ValueError):
+            return None
+    return None
+
+
+def geocode_address(address: str) -> Optional[Tuple[float, float]]:
+    """Return (lat, lon) for address or None."""
+    coords = _geocode_geoapify(address)
+    if coords:
+        return coords
+    return _geocode_nominatim(address)

--- a/orders/signals.py
+++ b/orders/signals.py
@@ -1,8 +1,13 @@
+import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from .assignment import pick_warehouse
-from .models import OrderItem
+from .services.destinations import ensure_order_coords
+from .models import Order, OrderItem
+
+logger = logging.getLogger(__name__)
+
 
 
 @receiver(post_save, sender=OrderItem)
@@ -14,3 +19,15 @@ def assign_warehouse_on_create(sender, instance, created, **kwargs):
     if wh:
         instance.warehouse = wh
         instance.save(update_fields=["warehouse"])
+
+
+@receiver(post_save, sender=Order)
+def geocode_order_on_save(sender, instance, created, **kwargs):
+    if instance.latitude is not None and instance.longitude is not None:
+        return
+    if not instance.address:
+        return
+    try:
+        ensure_order_coords(instance)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Order geocode signal failed: %s", exc)

--- a/orders/test_geocoding.py
+++ b/orders/test_geocoding.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from orders.models import Order
+from orders.services.destinations import ensure_order_coords
+from orders.services.geocoding import geocode_address
+
+
+class GeocodeAddressTests(SimpleTestCase):
+    @override_settings(GEOAPIFY_API_KEY="x")
+    @patch("orders.services.geocoding.httpx.Client.get")
+    def test_fallback_to_nominatim(self, mock_get):
+        geo_resp = Mock(status_code=500, json=Mock(return_value={}))
+        nom_resp = Mock(status_code=200, json=Mock(return_value=[{"lat": "1", "lon": "2"}]))
+        mock_get.side_effect = [geo_resp, nom_resp]
+        coords = geocode_address("addr")
+        self.assertEqual(coords, (1.0, 2.0))
+        self.assertEqual(mock_get.call_count, 2)
+
+
+class EnsureOrderCoordsTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="u", password="p")
+
+    @patch("orders.services.destinations.geocode_address")
+    def test_updates_missing_coords(self, mock_geo):
+        mock_geo.return_value = (1.1, 2.2)
+        order = Order.objects.create(user=self.user, full_name="F", email="e@e.com", address="A")
+        changed = ensure_order_coords(order)
+        self.assertTrue(changed)
+        order.refresh_from_db()
+        self.assertAlmostEqual(order.latitude, 1.1)
+        self.assertAlmostEqual(order.longitude, 2.2)

--- a/orders/views.py
+++ b/orders/views.py
@@ -17,6 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from orders.utils import reverse_geocode
 from orders.services import assign_warehouses_and_update_stock
+from .services.destinations import ensure_order_coords
 from django.utils import timezone
 from .models import Transaction, EmailDispatchLog
 
@@ -99,6 +100,7 @@ def order_create(request):
                         order = form.save(commit=False)
                         order.user = request.user
                         order.save()
+                        ensure_order_coords(order)
 
                         # Create order items for selected cart items
                         for item in cart.items.filter(is_selected=True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ stripe==12.3.0
 typing_extensions==4.14.1
 tzdata==2025.2
 urllib3==2.4.0
+httpx>=0.27

--- a/users/templates/users/accounts/my_orders.html
+++ b/users/templates/users/accounts/my_orders.html
@@ -29,7 +29,7 @@
                         <div class="border rounded p-2 mt-2">
                             <p>{{ item.quantity }} x {{ item.product.name }}</p>
                             <p class="text-sm">Delivery status: {{ item.delivery_status }}</p>
-                            <button class="track-item-btn" data-order-id="{{ order.id }}" data-item-id="{{ item.id }}" data-clat="{{ order.latitude|default_if_none:'' }}" data-clng="{{ order.longitude|default_if_none:'' }}">Track</button>
+                            <button class="track-item-btn" data-order-id="{{ order.id }}" data-item-id="{{ item.id }}" data-clat="{{ order.latitude|default_if_none:'' }}" data-clng="{{ order.longitude|default_if_none:'' }}" data-whlat="{{ item.warehouse.latitude|default_if_none:'' }}" data-whlng="{{ item.warehouse.longitude|default_if_none:'' }}">Track</button>
                             <div id="map-{{ order.id }}-{{ item.id }}" class="w-full h-64 rounded hidden"></div>
                         </div>
                     {% endfor %}
@@ -68,12 +68,16 @@
     const itemId  = btn.dataset.itemId;
     const lat = parseFloat(btn.dataset.clat);
     const lng = parseFloat(btn.dataset.clng);
+    const hasDest = !(isNaN(lat) || isNaN(lng));
 
     const mapDiv = document.getElementById(`map-${orderId}-${itemId}`);
     if (!mapDiv) return console.warn('No map div');
-    if (isNaN(lat) || isNaN(lng)) {
-      mapDiv.textContent = 'Missing destination coordinates.';
-      return;
+    if (!hasDest && !mapDiv._noDestMsg) {
+      const note = document.createElement('div');
+      note.textContent = 'Destination not set — showing live trail only.';
+      note.className = 'text-sm text-gray-500 mb-1';
+      mapDiv.parentNode.insertBefore(note, mapDiv);
+      mapDiv._noDestMsg = true;
     }
 
     // 1) Show first, then build/resize


### PR DESCRIPTION
## Summary
- add Geoapify/Nominatim geocoding service and helper to ensure order coordinates
- geocode orders on save, via admin action, and management command backfill
- allow tracking UI without destination coords and add geocoding settings

## Testing
- `pip install httpx>=0.27` (failed: Cannot connect to proxy)
- `python manage.py test orders` (failed: ModuleNotFoundError: No module named 'httpx')


------
https://chatgpt.com/codex/tasks/task_e_689710d7e880832abf4bb822b877e096