### PR TITLE
feat(users): add role groups and sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,26 @@ Set the `GEOAPIFY_API_KEY` environment variable in production and restrict the
 key in the Geoapify dashboard to your backend domain. Only the backend calls
 Geoapify; the key is never exposed to the browser.
 
+## Roles & permissions
+
+The project provisions Django groups for five roles: **Admin**, **Customer**,
+**Vendor**, **Vendor Staff**, and **Driver**.
+
+Apply migrations and sync the role groups:
+
+```bash
+python manage.py migrate
+python manage.py sync_roles
+```
+
+Running `sync_roles` multiple times is safe and updates any missing groups or
+permissions.
+
+### Smoke test
+
+```bash
+python manage.py migrate
+python manage.py sync_roles
+python manage.py test users
+```
+

--- a/users/management/commands/sync_roles.py
+++ b/users/management/commands/sync_roles.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+from users.roles import sync_roles
+
+
+class Command(BaseCommand):
+    help = "Synchronize role groups and permissions"
+
+    def handle(self, *args, **options):
+        sync_roles()
+        self.stdout.write(self.style.SUCCESS("Roles synced"))
+

--- a/users/migrations/0002_sync_roles.py
+++ b/users/migrations/0002_sync_roles.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    from users.roles import sync_roles
+
+    sync_roles()
+
+
+def reverse(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    roles = [
+        "Admin",
+        "Customer",
+        "Vendor",
+        "Vendor Staff",
+        "Driver",
+    ]
+    Group.objects.filter(name__in=roles).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0001_initial"),
+    ]
+
+    operations = [migrations.RunPython(forwards, reverse)]
+

--- a/users/roles.py
+++ b/users/roles.py
@@ -1,0 +1,39 @@
+from django.contrib.auth.models import Group, Permission
+
+ROLE_ADMIN = "Admin"
+ROLE_CUSTOMER = "Customer"
+ROLE_VENDOR = "Vendor"
+ROLE_VENDOR_STAFF = "Vendor Staff"
+ROLE_DRIVER = "Driver"
+
+ROLE_DEFINITIONS = {
+    ROLE_ADMIN: {"all_perms": True},
+    ROLE_CUSTOMER: {"perms": []},
+    ROLE_VENDOR: {
+        "perms": [
+            "add_product",
+            "change_product",
+            "delete_product",
+            "view_product",
+        ]
+    },
+    ROLE_VENDOR_STAFF: {
+        "perms": [
+            "change_product",
+            "view_product",
+        ]
+    },
+    ROLE_DRIVER: {"perms": ["view_order", "view_orderitem"]},
+}
+
+
+def sync_roles():
+    """Create or update role groups and attach permissions."""
+    for role, opts in ROLE_DEFINITIONS.items():
+        group, _ = Group.objects.get_or_create(name=role)
+        if opts.get("all_perms"):
+            perms = Permission.objects.all()
+        else:
+            perms = Permission.objects.filter(codename__in=opts.get("perms", []))
+        group.permissions.set(perms)
+

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,27 @@
+from django.contrib.auth.models import Group
+from django.core.management import call_command
 from django.test import TestCase
 
-# Create your tests here.
+from .roles import (
+    ROLE_ADMIN,
+    ROLE_CUSTOMER,
+    ROLE_DRIVER,
+    ROLE_VENDOR,
+    ROLE_VENDOR_STAFF,
+)
+
+
+class SyncRolesTests(TestCase):
+    def test_idempotent(self):
+        call_command("sync_roles")
+        call_command("sync_roles")
+        roles = [
+            ROLE_ADMIN,
+            ROLE_CUSTOMER,
+            ROLE_VENDOR,
+            ROLE_VENDOR_STAFF,
+            ROLE_DRIVER,
+        ]
+        for role in roles:
+            self.assertEqual(Group.objects.filter(name=role).count(), 1)
+


### PR DESCRIPTION
## Summary
- define role constants and sync helper
- provision groups via migration and management command
- ensure sync is idempotent with tests
- document role setup and smoke tests in README

## Testing
- `python manage.py migrate`
- `python manage.py sync_roles`
- `python manage.py test users`


------
https://chatgpt.com/codex/tasks/task_e_689841759f5c832ab7075ceb01a2fe56