### PR TITLE
feat: vendor & driver dashboards (read-only) + scoped APIs + auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ python manage.py sync_roles
 python manage.py test users
 ```
 
+## Auth tokens
+
+Obtain JWTs for API access:
+
+```
+POST /api/auth/token/ {"username": "<user>", "password": "<pass>"}
+POST /api/auth/token/refresh/ {"refresh": "<token>"}
+```
+
+Dashboards are available for vendors and drivers at `/users/vendor-dashboard/`
+and `/users/driver-dashboard/` respectively. Matching read-only APIs live under
+`/api/vendor/products/` and `/api/driver/deliveries/`.
+

--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -121,6 +121,7 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ],
 }
 SIMPLE_JWT = {
@@ -297,6 +298,7 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
     ],
 }
 SIMPLE_JWT = {

--- a/Rahim_Online_ClothesStore/urls.py
+++ b/Rahim_Online_ClothesStore/urls.py
@@ -30,6 +30,8 @@ urlpatterns = [
                   path('orders/', include("orders.urls",namespace='orders')),
                   # path('mpesa/', include('Mpesa.urls')),  # [Inactive] Preserved for future testing
                   path('', views.product_list, name='index'),
+
+                  path('api/', include('apis.urls')),
                   
 
                   path('webhook/paystack/', paystack_webhook, name='paystack_webhook'),  # ✅ direct path, no include

--- a/apis/permissions.py
+++ b/apis/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission
+
+class InGroups(BasePermission):
+    """Allow access only to users in specific Django groups."""
+    def has_permission(self, request, view):
+        required = getattr(view, "required_groups", [])
+        return (
+            request.user
+            and request.user.is_authenticated
+            and request.user.groups.filter(name__in=required).exists()
+        )

--- a/apis/serializers.py
+++ b/apis/serializers.py
@@ -1,0 +1,26 @@
+from django.apps import apps
+from rest_framework import serializers
+from product_app.models import Product
+from orders.models import OrderItem
+
+class OrderItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OrderItem
+        fields = ["id", "order", "product", "price", "quantity", "delivery_status"]
+
+class ProductSerializer(serializers.ModelSerializer):
+    order_items = OrderItemSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Product
+        fields = ["id", "name", "price", "available", "order_items"]
+
+# Delivery serializer is optional
+Delivery = apps.get_model('orders', 'Delivery')
+if Delivery:
+    class DeliverySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Delivery
+            fields = "__all__"
+else:
+    DeliverySerializer = None

--- a/apis/urls.py
+++ b/apis/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from .views import VendorProductsAPI, DriverDeliveriesAPI
+
+urlpatterns = [
+    path('vendor/products/', VendorProductsAPI.as_view(), name='vendor-products'),
+    path('driver/deliveries/', DriverDeliveriesAPI.as_view(), name='driver-deliveries'),
+    path('auth/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+]

--- a/apis/views.py
+++ b/apis/views.py
@@ -1,3 +1,41 @@
-from django.shortcuts import render
+from django.apps import apps
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from .permissions import InGroups
+from .serializers import ProductSerializer, DeliverySerializer
+from product_app.utils import get_vendor_field
+from product_app.models import Product
+from users.roles import ROLE_VENDOR, ROLE_VENDOR_STAFF, ROLE_DRIVER
+import logging
 
-# Create your views here.
+logger = logging.getLogger(__name__)
+
+class VendorProductsAPI(APIView):
+    permission_classes = [IsAuthenticated, InGroups]
+    required_groups = [ROLE_VENDOR, ROLE_VENDOR_STAFF]
+
+    def get(self, request):
+        field = get_vendor_field(Product)
+        try:
+            products = Product.objects.filter(**{field: request.user}).prefetch_related(
+                'order_items'
+            )
+        except Exception:
+            logger.warning("Product model missing vendor field '%s'", field)
+            products = Product.objects.none()
+        serializer = ProductSerializer(products, many=True)
+        return Response(serializer.data)
+
+
+class DriverDeliveriesAPI(APIView):
+    permission_classes = [IsAuthenticated, InGroups]
+    required_groups = [ROLE_DRIVER]
+
+    def get(self, request):
+        Delivery = apps.get_model('orders', 'Delivery')
+        if not Delivery or DeliverySerializer is None:
+            return Response([])
+        deliveries = Delivery.objects.filter(driver=request.user)
+        serializer = DeliverySerializer(deliveries, many=True)
+        return Response(serializer.data)

--- a/product_app/utils.py
+++ b/product_app/utils.py
@@ -13,3 +13,20 @@ def reverse_geocode(lat, lon):
     if response.status_code == 200:
         return response.json()
     return None
+
+import logging
+from django.core.exceptions import FieldDoesNotExist
+
+logger = logging.getLogger(__name__)
+
+VENDOR_FIELDS = ["vendor", "owner", "user", "created_by"]
+
+def get_vendor_field(model):
+    for field in VENDOR_FIELDS:
+        try:
+            model._meta.get_field(field)
+            return field
+        except FieldDoesNotExist:
+            continue
+    logger.warning("No vendor FK field found on %s; defaulting to 'vendor'", model.__name__)
+    return "vendor"

--- a/templates/includes/nav.html
+++ b/templates/includes/nav.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load roles %}
 <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
@@ -39,6 +40,20 @@
           class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
           <i class="fas fa-user-circle text-xl mr-1"></i> Profile
         </a>
+        {% if user|has_group:"Vendor" or user|has_group:"Vendor Staff" %}
+        <a
+          href="{% url 'users:vendor_dashboard' %}"
+          class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
+          Vendor Dashboard
+        </a>
+        {% endif %}
+        {% if user|has_group:"Driver" %}
+        <a
+          href="{% url 'users:driver_dashboard' %}"
+          class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
+          Driver Dashboard
+        </a>
+        {% endif %}
         {% endif %}
 
         <div class="flex items-center space-x-6">
@@ -119,6 +134,16 @@
           class="px-4 py-2 text-indigo-600 hover:text-indigo-800">
           <i class="fas fa-user-circle mr-2"></i> Profile
         </a>
+        {% if user|has_group:"Vendor" or user|has_group:"Vendor Staff" %}
+        <a
+          href="{% url 'users:vendor_dashboard' %}"
+          class="px-4 py-2 text-indigo-600 hover:text-indigo-800">Vendor Dashboard</a>
+        {% endif %}
+        {% if user|has_group:"Driver" %}
+        <a
+          href="{% url 'users:driver_dashboard' %}"
+          class="px-4 py-2 text-indigo-600 hover:text-indigo-800">Driver Dashboard</a>
+        {% endif %}
         <form method="post" action="{% url 'users:logout' %}" class="px-4 py-2">
           {% csrf_token %}
           <button

--- a/users/templates/users/driver_dashboard.html
+++ b/users/templates/users/driver_dashboard.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="text-xl font-bold mb-4">Driver Dashboard</h2>
+<ul>
+  {% for delivery in deliveries %}
+  <li class="mb-2">Delivery #{{ delivery.id }}</li>
+  {% empty %}
+  <li>No deliveries assigned.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/users/templates/users/vendor_dashboard.html
+++ b/users/templates/users/vendor_dashboard.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="text-xl font-bold mb-4">Vendor Dashboard</h2>
+<h3 class="font-semibold">Products</h3>
+<ul>
+  {% for product in products %}
+  <li class="mb-2">
+    {{ product.name }}
+  </li>
+  {% empty %}
+  <li>No products found.</li>
+  {% endfor %}
+</ul>
+<h3 class="font-semibold mt-6">Order Items</h3>
+<ul>
+  {% for item in order_items %}
+  <li class="mb-1">
+    {{ item.quantity }} x {{ item.product.name }} (Order #{{ item.order.id }})
+  </li>
+  {% empty %}
+  <li>No order items.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/users/templatetags/README.md
+++ b/users/templatetags/README.md
@@ -1,0 +1,10 @@
+# Template tags
+
+`has_group` filter checks if the current user belongs to a given Django group.
+
+```django
+{% load roles %}
+{% if user|has_group:"Vendor" %}
+  <!-- content for vendor -->
+{% endif %}
+```

--- a/users/templatetags/roles.py
+++ b/users/templatetags/roles.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def has_group(user, name):
+    return user.is_authenticated and user.groups.filter(name=name).exists()

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,17 @@
 from django.urls import path
 from .views import ResendActivationEmailView
 from django.contrib.auth import views as auth_views
-from users.views import CustomLoginView,Logout,RegisterUser,activate, profile_view,my_orders, geoapify_test
+from users.views import (
+    CustomLoginView,
+    Logout,
+    RegisterUser,
+    activate,
+    profile_view,
+    my_orders,
+    geoapify_test,
+    vendor_dashboard,
+    driver_dashboard,
+)
 from django.urls import reverse_lazy
 
 
@@ -14,6 +24,8 @@ path('activate/<uidb64>/<token>/', activate, name='activate'),
 path('profile/', profile_view, name='profile'),
 path('resend-activation/', ResendActivationEmailView.as_view(), name='resend_activation'),
 path('my-orders/', my_orders, name='my_orders'),
+path('vendor-dashboard/', vendor_dashboard, name='vendor_dashboard'),
+path('driver-dashboard/', driver_dashboard, name='driver_dashboard'),
 # Password reset URLs
     # These URLs are used for password reset functionality
     path('reset_password/', auth_views.PasswordResetView.as_view(


### PR DESCRIPTION
## Summary
- add `has_group` template filter and role-based nav links
- vendor and driver dashboards with matching API endpoints
- introduce `InGroups` permission and JWT token routes

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement anyio==4.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898a0b5ee0c832a81d18efdb11dc935