### PR TITLE
Add shopable products API and dashboard routing

### DIFF
--- a/Rahim_Online_ClothesStore/settings.py
+++ b/Rahim_Online_ClothesStore/settings.py
@@ -71,11 +71,9 @@ INSTALLED_APPS = [
     "dashboards",
     "django_extensions",
 ]
-INSTALLED_APPS += ["corsheaders"]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -85,6 +83,15 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "core.middleware.PermissionsPolicyMiddleware",  # keep last
 ]
+
+try:
+    import corsheaders  # noqa
+except ImportError:  # pragma: no cover
+    corsheaders = None
+
+if corsheaders:
+    INSTALLED_APPS += ["corsheaders"]
+    MIDDLEWARE.insert(1, "corsheaders.middleware.CorsMiddleware")
 
 AUTHENTICATION_BACKENDS = [
     "users.backends.EmailOrUsernameModelBackend",
@@ -146,7 +153,7 @@ SIMPLE_JWT = {
 
 AUTH_USER_MODEL = "users.CustomUser"
 
-LOGIN_REDIRECT_URL = "/after-login/"
+LOGIN_REDIRECT_URL = "/dashboard/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/Rahim_Online_ClothesStore/urls.py
+++ b/Rahim_Online_ClothesStore/urls.py
@@ -19,6 +19,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from product_app import views
+from users.views import after_login
 from django.conf import settings
 from django.conf.urls.static import static
 from orders.views import paystack_webhook
@@ -32,10 +33,11 @@ urlpatterns = [
                   path('', views.product_list, name='index'),
                   path('', include('dashboards.urls')),
                   path('', include('users.urls')),
+                  path('dashboard/', after_login, name='dashboard'),
                   path('accounts/', include('django.contrib.auth.urls')),
                   path('api/', include('apis.urls')),
                   path('webhook/paystack/', paystack_webhook, name='paystack_webhook'),
-                  path('<slug:category_slug>/', views.product_list, name='product_list_by_category'),
+                  path('category/<slug:category_slug>/', views.product_list, name='product_list_by_category'),
                   path('products/search/', views.SearchProduct, name='product_search'),
                   path('products/', include('product_app.urls', namespace='product_app')),  # Fixed syntax
                   path('accounts/profile/', views.profile, name='profile'),

--- a/apis/serializers.py
+++ b/apis/serializers.py
@@ -25,6 +25,26 @@ class ProductSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "price", "available", "order_items"]
 
 
+class ProductListSerializer(serializers.ModelSerializer):
+    owned_by_me = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Product
+        fields = ["id", "name", "price", "available", "slug", "owned_by_me"]
+
+    def get_owned_by_me(self, obj):
+        user = self.context["request"].user
+        if not user.is_authenticated:
+            return False
+        for name in ("owner", "vendor", "seller", "created_by", "user"):
+            try:
+                obj._meta.get_field(name)
+                return getattr(obj, f"{name}_id", None) == user.id
+            except Exception:
+                continue
+        return False
+
+
 # ---- Optional Delivery serializer (won't explode if model is absent) ----
 class EmptySerializer(serializers.Serializer):
     """Used when Delivery model doesn't exist."""

--- a/apis/tests/test_shopable_products.py
+++ b/apis/tests/test_shopable_products.py
@@ -1,0 +1,41 @@
+import django
+django.setup()
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from users.models import CustomUser, VendorStaff
+from product_app.models import Product, Category
+
+
+class ShopableProductsTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_vendor_does_not_see_own_products(self):
+        owner = CustomUser.objects.create_user(username="owner", password="x")
+        other = CustomUser.objects.create_user(username="other", password="x")
+        cat = Category.objects.create(name="Shirts", slug="shirts")
+        Product.objects.create(name="My Shirt", slug="my-shirt", price=1000, available=True, owner=owner, category=cat)
+        Product.objects.create(name="Other Shirt", slug="other-shirt", price=1200, available=True, owner=other, category=cat)
+
+        self.client.login(username="owner", password="x")
+        url = reverse("shopable-products")
+        data = self.client.get(url).json()
+        results = data.get("results") or data
+        names = [r["name"] for r in results]
+        self.assertNotIn("My Shirt", names)
+        self.assertIn("Other Shirt", names)
+
+    def test_staff_excluded_from_boss_products(self):
+        boss = CustomUser.objects.create_user(username="boss", password="x")
+        staff = CustomUser.objects.create_user(username="staff", password="x")
+        VendorStaff.objects.create(owner=boss, staff=staff, is_active=True)
+        cat = Category.objects.create(name="Pants", slug="pants")
+        Product.objects.create(name="Boss Item", slug="boss-item", price=500, available=True, owner=boss, category=cat)
+
+        self.client.login(username="staff", password="x")
+        url = reverse("shopable-products")
+        data = self.client.get(url).json()
+        results = data.get("results") or data
+        names = [r["name"] for r in results]
+        self.assertNotIn("Boss Item", names)

--- a/apis/urls.py
+++ b/apis/urls.py
@@ -9,11 +9,15 @@ from .views import (
     DeliveryStatusAPI,
     VendorProductCreateAPI,
     VendorApplyAPI,
+    ShopableProductsAPI,
+    DriverLocationAPI,
 )
 
 urlpatterns = [
     path('vendor/products/', VendorProductsAPI.as_view(), name='vendor-products'),
+    path('vendor/shopable-products/', ShopableProductsAPI.as_view(), name='shopable-products'),
     path('driver/deliveries/', DriverDeliveriesAPI.as_view(), name='driver-deliveries'),
+    path('driver/location/', DriverLocationAPI.as_view(), name='driver-location'),
     path('auth/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     # Delivery management endpoints

--- a/apis/utils.py
+++ b/apis/utils.py
@@ -1,0 +1,22 @@
+from django.db.models import Q
+
+def shopable_products_q(user, product_model):
+    """Return Q filtering out products owned by user or their active vendor bosses."""
+    owner_field = None
+    for name in ("owner", "vendor", "seller", "created_by", "user"):
+        try:
+            product_model._meta.get_field(name)
+            owner_field = name
+            break
+        except Exception:
+            continue
+    if not owner_field or not getattr(user, "is_authenticated", False):
+        return Q()
+
+    from users.models import VendorStaff
+    my_owner_ids = {user.id}
+    staffed_for = VendorStaff.objects.filter(
+        staff=user, is_active=True
+    ).values_list("owner_id", flat=True)
+    my_owner_ids.update(staffed_for)
+    return ~Q(**{f"{owner_field}_id__in": list(my_owner_ids)})

--- a/audit_rbac_apis_report.md
+++ b/audit_rbac_apis_report.md
@@ -1,0 +1,29 @@
+# RBAC API Audit
+
+## Endpoint summary
+
+| Pattern | Name | View | Auth/roles |
+| --- | --- | --- | --- |
+| `vendor/products/` | vendor-products | `VendorProductsAPI` | `IsAuthenticated` + `InGroups` Vendor/Vendor Staff |
+| `vendor/shopable-products/` | shopable-products | `ShopableProductsAPI` | `IsAuthenticatedOrReadOnly` |
+| `driver/deliveries/` | driver-deliveries | `DriverDeliveriesAPI` | `IsAuthenticated` + Driver group |
+| `driver/location/` | driver-location | `DriverLocationAPI` | `IsAuthenticated` + Driver group |
+| `deliveries/<int:pk>/assign/` | delivery-assign | `DeliveryAssignAPI` | `IsAuthenticated` + Vendor/Vendor Staff |
+| `deliveries/<int:pk>/unassign/` | delivery-unassign | `DeliveryUnassignAPI` | `IsAuthenticated` + Vendor/Vendor Staff |
+| `deliveries/<int:pk>/accept/` | delivery-accept | `DeliveryAcceptAPI` | `IsAuthenticated` + Driver |
+| `deliveries/<int:pk>/status/` | delivery-status | `DeliveryStatusAPI` | `IsAuthenticated` + Driver |
+| `vendor/products/create/` | vendor-product-create | `VendorProductCreateAPI` | `IsAuthenticated` + Vendor/Vendor Staff |
+| `vendor/apply/` | vendor-apply | `VendorApplyAPI` | `IsAuthenticated` |
+
+## Role checks
+
+* `users/views.py` – router `after_login` dispatches to vendor, driver and customer dashboards based on group membership.
+* `apis/views.py` – class based APIs use `InGroups` permission to require appropriate roles.
+
+## Gaps and Fixes
+
+* Added `shopable_products_q` filter to exclude vendor/staff own listings.
+* Introduced `ShopableProductsAPI` with `IsAuthenticatedOrReadOnly` and pagination.
+* Added driver location stub with authentication and group check.
+* Secured dashboard routing and added `/dashboard/` URL before category catch‑all.
+* Reworked navbar to expose a unified dashboard link for authenticated users.

--- a/templates/dash/customer.html
+++ b/templates/dash/customer.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="p-4">
+  <h2 class="text-xl">Welcome to your dashboard</h2>
+</div>
+{% endblock %}

--- a/templates/dash/driver.html
+++ b/templates/dash/driver.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<div id="driver-app" class="p-4"></div>
+<script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
+<script>
+new Vue({
+  el: '#driver-app',
+  data: { deliveries: [] },
+  mounted() {
+    fetch('/api/driver/deliveries/')
+      .then(r => r.json())
+      .then(d => { this.deliveries = d; });
+  },
+  template: `
+    <div>
+      <h2 class="text-xl mb-4">My Deliveries</h2>
+      <ul class="list-disc pl-5">
+        <li v-for="d in deliveries" :key="d.id">Delivery #{{ d.id }}</li>
+      </ul>
+    </div>`
+});
+</script>
+{% endblock %}

--- a/templates/dash/vendor.html
+++ b/templates/dash/vendor.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block content %}
+<div id="vendor-app" class="p-4"></div>
+<script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
+<script>
+new Vue({
+  el: '#vendor-app',
+  data: { products: [], q: '' },
+  mounted() { this.fetch(); },
+  methods: {
+    fetch() {
+      fetch('/api/vendor/shopable-products/?q=' + encodeURIComponent(this.q))
+        .then(r => r.json())
+        .then(data => { this.products = data.results || data; });
+    },
+    add(p) {
+      fetch('/cart/add/' + p.id + '/', { method: 'POST', headers: { 'X-CSRFToken': window.CSRF_TOKEN }})
+        .then(() => {});
+    }
+  },
+  template: `
+    <div>
+      <input v-model="q" @input="fetch" placeholder="Search" class="border p-2 mb-4" />
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div v-for="p in products" :key="p.id" class="border p-4">
+          <h3 class="font-semibold">{{ p.name }}</h3>
+          <p class="text-sm mb-2">{{ p.price }}</p>
+          <button :disabled="p.owned_by_me" @click="add(p)" class="mt-2 px-2 py-1 bg-blue-500 text-white rounded disabled:opacity-50">Add to cart</button>
+        </div>
+      </div>
+    </div>`
+});
+</script>
+{% endblock %}

--- a/templates/includes/nav.html
+++ b/templates/includes/nav.html
@@ -40,20 +40,11 @@
           class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
           <i class="fas fa-user-circle text-xl mr-1"></i> Profile
         </a>
-        {% if user|has_group:"Vendor" or user|has_group:"Vendor Staff" %}
         <a
-          href="{% url 'users:vendor_dashboard' %}"
+          href="{% url 'dashboard' %}"
           class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
-          Vendor Dashboard
+          Dashboard
         </a>
-        {% endif %}
-        {% if user|has_group:"Driver" %}
-        <a
-          href="{% url 'users:driver_dashboard' %}"
-          class="text-indigo-600 hover:text-indigo-800 transition-colors duration-300">
-          Driver Dashboard
-        </a>
-        {% endif %}
         {% endif %}
 
         <div class="flex items-center space-x-6">
@@ -134,16 +125,9 @@
           class="px-4 py-2 text-indigo-600 hover:text-indigo-800">
           <i class="fas fa-user-circle mr-2"></i> Profile
         </a>
-        {% if user|has_group:"Vendor" or user|has_group:"Vendor Staff" %}
         <a
-          href="{% url 'users:vendor_dashboard' %}"
-          class="px-4 py-2 text-indigo-600 hover:text-indigo-800">Vendor Dashboard</a>
-        {% endif %}
-        {% if user|has_group:"Driver" %}
-        <a
-          href="{% url 'users:driver_dashboard' %}"
-          class="px-4 py-2 text-indigo-600 hover:text-indigo-800">Driver Dashboard</a>
-        {% endif %}
+          href="{% url 'dashboard' %}"
+          class="px-4 py-2 text-indigo-600 hover:text-indigo-800">Dashboard</a>
         <form method="post" action="{% url 'users:logout' %}" class="px-4 py-2">
           {% csrf_token %}
           <button

--- a/users/views.py
+++ b/users/views.py
@@ -46,7 +46,7 @@ class CustomLoginView(LoginView):
     template_name = "users/accounts/login.html"
     redirect_authenticated_user = True
     # fallback if no ?next= — send to role router
-    success_url = reverse_lazy("users:after_login")   # ← use your namespaced route
+    success_url = reverse_lazy("dashboard")
 
     def form_valid(self, form):
         # --- capture “how” the user logged in ---
@@ -328,7 +328,7 @@ def geoapify_test(request):
 def after_login(request):
     u = request.user
     if u.is_staff or u.groups.filter(name__in=["Vendor", "Vendor Staff"]).exists():
-        return redirect("users:vendor_dashboard")
+        return render(request, "dash/vendor.html")
     if u.groups.filter(name="Driver").exists():
-        return redirect("users:driver_dashboard")
-    return redirect("index")
+        return render(request, "dash/driver.html")
+    return render(request, "dash/customer.html")


### PR DESCRIPTION
## Summary
- filter out vendor-owned products with `shopable_products_q`
- add shopable products and driver location APIs
- route `/dashboard/` to role-specific Vue dashboards and expose dashboard link
- document RBAC endpoints

## Testing
- `PYTHONPATH=. DJANGO_SETTINGS_MODULE=Rahim_Online_ClothesStore.settings pytest apis/tests/test_shopable_products.py -q` *(fails: no such table: users_customuser)*

------
https://chatgpt.com/codex/tasks/task_e_689c67d321cc832a8de0fb05ebab646d