### PR TITLE
Refactor vendor utilities and unify self-purchase guard

### DIFF
--- a/apis/tests/test_shopable_products.py
+++ b/apis/tests/test_shopable_products.py
@@ -12,13 +12,13 @@ class ShopableProductsTests(TestCase):
         self.client = APIClient()
 
     def test_vendor_does_not_see_own_products(self):
-        owner = CustomUser.objects.create_user(username="owner", password="x")
-        other = CustomUser.objects.create_user(username="other", password="x")
+        owner = CustomUser.objects.create_user(username="owner", email="owner@example.com", password="x")
+        other = CustomUser.objects.create_user(username="other", email="other@example.com", password="x")
         cat = Category.objects.create(name="Shirts", slug="shirts")
         Product.objects.create(name="My Shirt", slug="my-shirt", price=1000, available=True, owner=owner, category=cat)
         Product.objects.create(name="Other Shirt", slug="other-shirt", price=1200, available=True, owner=other, category=cat)
 
-        self.client.login(username="owner", password="x")
+        self.client.login(username="owner", email="owner@example.com", password="x")
         url = reverse("shopable-products")
         data = self.client.get(url).json()
         results = data.get("results") or data
@@ -27,13 +27,13 @@ class ShopableProductsTests(TestCase):
         self.assertIn("Other Shirt", names)
 
     def test_staff_excluded_from_boss_products(self):
-        boss = CustomUser.objects.create_user(username="boss", password="x")
-        staff = CustomUser.objects.create_user(username="staff", password="x")
+        boss = CustomUser.objects.create_user(username="boss", email="boss@example.com", password="x")
+        staff = CustomUser.objects.create_user(username="staff", email="staff@example.com", password="x")
         VendorStaff.objects.create(owner=boss, staff=staff, is_active=True)
         cat = Category.objects.create(name="Pants", slug="pants")
         Product.objects.create(name="Boss Item", slug="boss-item", price=500, available=True, owner=boss, category=cat)
 
-        self.client.login(username="staff", password="x")
+        self.client.login(username="staff", email="staff@example.com", password="x")
         url = reverse("shopable-products")
         data = self.client.get(url).json()
         results = data.get("results") or data

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -1,7 +1,6 @@
 from rest_framework.permissions import BasePermission
 from users.constants import VENDOR, VENDOR_STAFF, DRIVER
 from users.utils import in_groups
-from users.models import VendorStaff
 
 
 class InGroups(BasePermission):
@@ -19,30 +18,3 @@ class IsVendorOrStaff(InGroups):
     required_groups = (VENDOR, VENDOR_STAFF)
 
 
-class NotBuyingOwnListing(BasePermission):
-    message = "You cannot purchase your own or your vendor's listing."
-
-    def _is_forbidden(self, user, product) -> bool:
-        if not getattr(user, "is_authenticated", False):
-            return False
-        owner_id = getattr(product, "owner_id", None)
-        if owner_id is None:
-            return False
-        if owner_id == user.id:
-            return True
-        return VendorStaff.objects.filter(
-            owner_id=owner_id, staff_id=user.id, is_active=True
-        ).exists()
-
-    def has_permission(self, request, view):
-        return True
-
-    def has_object_permission(self, request, view, obj):
-        from product_app.models import Product
-        from orders.models import OrderItem
-
-        if isinstance(obj, Product):
-            return not self._is_forbidden(request.user, obj)
-        if isinstance(obj, OrderItem):
-            return not self._is_forbidden(request.user, obj.product)
-        return True

--- a/orders/services/__init__.py
+++ b/orders/services/__init__.py
@@ -7,7 +7,7 @@ from django.db.models import F
 
 from product_app.models import Product, ProductStock
 
-from core.permissions import NotBuyingOwnListing
+from users.permissions import NotBuyingOwnListing
 
 from ..assignment import pick_warehouse
 from ..models import Order, OrderItem

--- a/orders/test_delivery_ws.py
+++ b/orders/test_delivery_ws.py
@@ -13,12 +13,12 @@ from product_app.models import Category, Product, Warehouse
 class DeliveryConsumerTests(TestCase):
     def setUp(self):
         User = get_user_model()
-        self.owner = User.objects.create_user(username="owner", password="p")
-        self.driver = User.objects.create_user(username="driver", password="p")
-        self.other = User.objects.create_user(username="other", password="p")
+        self.owner = User.objects.create_user(username="owner", email="owner@example.com", password="p")
+        self.driver = User.objects.create_user(username="driver", email="driver@example.com", password="p")
+        self.other = User.objects.create_user(username="other", email="other@example.com", password="p")
         cat = Category.objects.create(name="c", slug="c")
         prod = Product.objects.create(category=cat, name="p", slug="p", price=10)
-        wh = Warehouse.objects.create(name="w", latitude=0, longitude=0)
+        wh = Warehouse.objects.create(name="w", latitude=1, longitude=37)
         order = Order.objects.create(
             user=self.owner,
             full_name="F",
@@ -48,9 +48,7 @@ class DeliveryConsumerTests(TestCase):
             connected, _ = await comm.connect()
             if connected:
                 await comm.receive_nothing()
-                code = await comm.wait_closed()
-            else:
-                code = comm.close_code
+            code = await comm.wait_closed()
             return code
         code = async_to_sync(flow)()
         self.assertEqual(code, 4003)

--- a/users/utils.py
+++ b/users/utils.py
@@ -30,6 +30,11 @@ def is_vendor_or_staff(user) -> bool:
     return in_groups(user, VENDOR, VENDOR_STAFF) or getattr(user, "is_staff", False)
 
 
+def get_active_vendor_staff(user):
+    from .models import VendorStaff
+    return VendorStaff.objects.filter(staff=user, is_active=True)
+
+
 def vendor_owner_ids_for(user):
     """
     Returns the set of owner User IDs that this user acts for:


### PR DESCRIPTION
## Summary
- centralize vendor owner resolution helpers and expose vendor staff lookup
- consolidate NotBuyingOwnListing into users.permissions and update imports
- adjust tests for unique emails and valid delivery setup

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate`
- `python manage.py test` *(fails: AttributeError: 'WebsocketCommunicator' object has no attribute 'wait_closed'; AssertionError in geocoding test)*

------
https://chatgpt.com/codex/tasks/task_e_68a17f19d2cc832aa0d645dca5e60cf1