### PR TITLE
Normalize VendorStaff active status via data migration

### DIFF
--- a/users/migrations/0003_vendorstaff_normalize_active.py
+++ b/users/migrations/0003_vendorstaff_normalize_active.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from django.utils import timezone
+
+
+def forwards(apps, schema_editor):
+    VendorStaff = apps.get_model("users", "VendorStaff")
+    now = timezone.now()
+    VendorStaff.objects.filter(status="accepted", accepted_at__isnull=True).update(accepted_at=now)
+    VendorStaff.objects.filter(status="accepted").update(is_active=True)
+    VendorStaff.objects.exclude(status="accepted").update(is_active=False)
+
+
+def backwards(apps, schema_editor):
+    VendorStaff = apps.get_model("users", "VendorStaff")
+    VendorStaff.objects.exclude(status="accepted").update(is_active=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0002_vendorstaff_schema_hardening"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]


### PR DESCRIPTION
## Summary
- add data migration to keep VendorStaff.is_active in sync with status and backfill accepted_at

## Testing
- `SECRET_KEY=testsecret python manage.py test users.tests.test_vendor_staff_accept` *(fails: KeyError: ('users', 'vendorstaff'))*


------
https://chatgpt.com/codex/tasks/task_e_68a4838adda4832a9335bd713397ccea