### PR TITLE
Add VendorStaff audit and fix commands with runbook

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,16 @@
+# VendorStaff one-time maintenance
+
+```bash
+git switch -c fix/vendorstaff-0822
+python manage.py makemigrations && python manage.py migrate
+python manage.py audit_vendorstaff
+python manage.py fix_vendorstaff
+pytest -q -k vendorstaff
+```
+
+## Rollback
+
+```bash
+git restore .
+python manage.py migrate users 0003
+```

--- a/users/management/commands/audit_vendorstaff.py
+++ b/users/management/commands/audit_vendorstaff.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Count, F, Q
+
+from users.models import VendorStaff
+
+
+class Command(BaseCommand):
+    help = "Audit VendorStaff for common data issues"
+
+    def handle(self, *args, **options):
+        qs = VendorStaff.objects.all()
+
+        self_links = qs.filter(owner=F("staff"))
+        self.stdout.write(f"Self links: {self_links.count()}")
+        for vs in self_links:
+            self.stdout.write(f"  - id={vs.id} owner={vs.owner_id}")
+
+        exact_dups = (
+            qs.values("owner_id", "staff_id", "role", "is_active")
+            .annotate(c=Count("id"))
+            .filter(c__gt=1)
+        )
+        self.stdout.write(f"Exact duplicates: {exact_dups.count()}")
+        for row in exact_dups:
+            self.stdout.write(
+                f"  - owner={row['owner_id']} staff={row['staff_id']} role={row['role']} is_active={row['is_active']} count={row['c']}"
+            )
+
+        active_dups = (
+            qs.filter(is_active=True)
+            .values("owner_id", "staff_id")
+            .annotate(c=Count("id"))
+            .filter(c__gt=1)
+        )
+        self.stdout.write(f"Active duplicates: {active_dups.count()}")
+        for row in active_dups:
+            self.stdout.write(
+                f"  - owner={row['owner_id']} staff={row['staff_id']} active_count={row['c']}"
+            )
+
+        inactive_blockers = (
+            qs.filter(is_active=False)
+            .values("owner_id", "staff_id")
+            .annotate(
+                inactive_count=Count("id"),
+                active_count=Count("id", filter=Q(is_active=True)),
+            )
+            .filter(active_count=0)
+        )
+        self.stdout.write(
+            f"Inactive rows blocking re-invite: {inactive_blockers.count()}"
+        )
+        for row in inactive_blockers:
+            self.stdout.write(
+                f"  - owner={row['owner_id']} staff={row['staff_id']} inactive_count={row['inactive_count']}"
+            )

--- a/users/management/commands/fix_vendorstaff.py
+++ b/users/management/commands/fix_vendorstaff.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from users.models import VendorStaff
+
+
+class Command(BaseCommand):
+    help = "Deactivate duplicate active VendorStaff rows, keeping the newest"
+
+    def handle(self, *args, **options):
+        deactivated = 0
+        pairs = (
+            VendorStaff.objects.values("owner_id", "staff_id")
+            .annotate(c=Count("id"))
+            .filter(c__gt=1)
+        )
+        with transaction.atomic():
+            for pair in pairs:
+                memberships = (
+                    VendorStaff.objects.filter(
+                        owner_id=pair["owner_id"], staff_id=pair["staff_id"]
+                    )
+                    .order_by("-created_at", "-id")
+                )
+                keep = memberships.first()
+                for member in memberships[1:]:
+                    if member.is_active:
+                        member.is_active = False
+                        member.save(update_fields=["is_active"])
+                        deactivated += 1
+        self.stdout.write(f"Pairs processed: {pairs.count()}")
+        self.stdout.write(f"Memberships deactivated: {deactivated}")


### PR DESCRIPTION
## Summary
- add management command to audit VendorStaff for self-links and duplicates
- add management command to deactivate duplicate active VendorStaff rows
- document runbook for vendor staff maintenance

## Testing
- `pytest -q -k vendorstaff` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a81ae43908832ab679c18a5a9f50bb