### PR TITLE
Fix decimal arithmetic for order totals and cart items

### DIFF
--- a/cart/models.py
+++ b/cart/models.py
@@ -1,9 +1,7 @@
 from django.db import models
 from django.db.models import Sum
 from product_app.models import Product
-from django.contrib.auth.models import User
-from users.models import CustomUser
-from decimal import Decimal, ROUND_HALF_UP
+from orders.money import D
 
 
 class Cart(models.Model):
@@ -11,12 +9,15 @@ class Cart(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def get_total_price(self):
-        # Sum the price for each CartItem
-        return sum(item.get_total_price() for item in self.items.all())
-    
+        """Return the total price for all items as a Decimal."""
+        return sum((item.get_total_price() for item in self.items.all()), D("0.00"))
+
     def get_selected_total_price(self):
-        # Sum the price for only selected CartItems
-        return sum(item.get_total_price() for item in self.items.filter(is_selected=True))
+        """Return the total price for only selected items as a Decimal."""
+        return sum(
+            (item.get_total_price() for item in self.items.filter(is_selected=True)),
+            D("0.00"),
+        )
 
     def total_items(self):
         return self.items.aggregate(
@@ -44,7 +45,8 @@ class CartItem(models.Model):
 
 
     def get_total_price(self):
-        return int(self.product.price * self.quantity)
+        """Cost of this cart item (price * quantity) as a Decimal."""
+        return D(self.product.price) * self.quantity
 
     def __str__(self):
         return f"{self.quantity} x {self.product.name}"

--- a/orders/services/totals.py
+++ b/orders/services/totals.py
@@ -1,10 +1,23 @@
-from decimal import Decimal
-from orders.money import q2
+"""Helpers for computing order totals using Decimals only."""
+
+# Re-use Decimal utilities from the money module so that any value – even a
+# float – is safely converted before arithmetic.  This prevents mixing native
+# Python ``float`` values with :class:`decimal.Decimal` which would otherwise
+# raise ``TypeError`` during operations such as subtraction.
+from orders.money import D, q2
 
 def safe_order_total(order):
     items = order.items.select_related("product").all()
-    subtotal = sum((i.price * i.quantity for i in items), Decimal("0.00"))
-    shipping = getattr(order, "shipping_fee", None) or Decimal("0.00")
-    discount = getattr(order, "discount", None) or Decimal("0.00")
-    tax      = getattr(order, "tax", None) or Decimal("0.00")
+
+    # Ensure each item's price participates in Decimal arithmetic.  Starting the
+    # sum with ``D('0.00')`` guarantees the result is also a ``Decimal``.
+    subtotal = sum((D(i.price) * i.quantity for i in items), D("0.00"))
+
+    # Values stored on the order (e.g. shipping_fee) may be floats.  Wrapping
+    # them with ``D`` normalises them to Decimals before performing the maths
+    # below, avoiding ``float - Decimal`` type errors.
+    shipping = D(getattr(order, "shipping_fee", 0) or 0)
+    discount = D(getattr(order, "discount", 0) or 0)
+    tax = D(getattr(order, "tax", 0) or 0)
+
     return q2(subtotal - discount + shipping + tax)


### PR DESCRIPTION
## Summary
- normalize cart total helpers to use `orders.money.D`
- convert order totals and components to `Decimal`

## Testing
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68abc999bebc832aa912e6e47e147bde